### PR TITLE
JJ: change contact link on careers page to email to recruiting

### DIFF
--- a/app/views/careers/show.haml
+++ b/app/views/careers/show.haml
@@ -34,6 +34,6 @@
       %h6.c-drk-gray= @career.cta_title
       %p.p-top-5= @career.cta_copy
     .small-12.medium-3.columns
-      = link_to contact_path, :class => "btn btn-empty btn-m btn-block" do
-        %span.btn-text Contact Us
-        %span.btn-text.f-right{"data-icon" => "c"}
+      = link_to "mailto:recruiting@bloomconsultinggroup.com", :class => "btn btn-empty btn-m btn-block" do
+        %span.btn-text Email Us
+        %span.btn-text.f-right{"data-icon" => "f"}


### PR DESCRIPTION
- Make contact button on careers page a mailto link
